### PR TITLE
Adding support for inline form input plus adding accept headers

### DIFF
--- a/demo/inline.html
+++ b/demo/inline.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RDF Form</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script type="module" src="/inline.js">
+    </script>
+</head>
+<body>
+
+</body>
+</html>

--- a/demo/inline.js
+++ b/demo/inline.js
@@ -1,0 +1,69 @@
+import 'rdf-form'
+
+const form = document.createElement('rdf-form')
+form.setAttribute('form', `
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix form:  <http://rdf.danielbeeke.nl/form/form-dev.ttl#> .
+@prefix ex:    <https://example.org/#> .
+@prefix dc:    <http://purl.org/dc/terms/> .
+@prefix :      <http://localhost/todo-form.ttl#> .
+
+:form a form:Form ;
+    form:binding ex:Todo .
+
+:todo
+    a form:Field ;
+    form:binding ex:items ;
+    form:widget "group" ;
+    form:multiple true ;
+    form:label "Todo items" ;
+    form:required true ;
+    form:order 1 .
+
+:todoItem
+    a form:Field ;
+    form:binding ex:task ;
+    form:widget "string" ;
+    form:group "todo" ;
+    form:label "Task" ;
+    form:required true ;
+    form:order 1 .
+
+:todoCheck
+    a form:Field ;
+    form:binding ex:completed ;
+    form:widget "checkbox" ;
+    form:group "todo" ;
+    form:label "Done" ;
+    form:order 2 .
+`)
+form.setAttribute('data', `
+{
+    "@type": "https://example.org/#Todo",
+    "https://example.org/#items": {
+      "@list": [
+        {
+          "https://example.org/#completed": true,
+          "https://example.org/#task": "Wake up"
+        },
+        {
+          "https://example.org/#completed": true,
+          "https://example.org/#task": "Drink coffee"
+        },
+        {
+          "https://example.org/#task": "Breakfast"
+        },
+        {
+          "https://example.org/#task": " the world"
+        }
+      ]
+    }
+}
+`)
+
+form.addEventListener('submit', (event) => {
+  console.log(event.detail)
+})
+
+document.body.appendChild(form)

--- a/demo/inline.js
+++ b/demo/inline.js
@@ -55,7 +55,7 @@ form.setAttribute('data', `
           "https://example.org/#task": "Breakfast"
         },
         {
-          "https://example.org/#task": " the world"
+          "https://example.org/#task": "Save the world"
         }
       ]
     }

--- a/src/core/RdfFormData.ts
+++ b/src/core/RdfFormData.ts
@@ -34,7 +34,12 @@ export class RdfFormData extends EventTarget implements CoreComponent {
     if (!this.dataAsTextOrUrl) this.sourceData = []
 
     if (this.dataAsTextOrUrl && isFetchable(this.dataAsTextOrUrl)) {
-      const dataResponse = await fetch(applyProxy(this.dataAsTextOrUrl, proxy))
+      const dataResponse = await fetch(applyProxy(this.dataAsTextOrUrl, proxy), {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/ld+json'
+          }
+      })
       dataText = await dataResponse.text()
     }
     else {


### PR DESCRIPTION
This pull request adds support to:

- Pass form data by value (as text string)
- Add content negotiation when requesting data and form data 
    - Form data requests `text/turtle`
    - Data requests `application/ld+json`