### PR TITLE
Fixing deletion of readonly multiple

### DIFF
--- a/src/elements/ElementBase.ts
+++ b/src/elements/ElementBase.ts
@@ -157,7 +157,7 @@ export class ElementBase extends EventTarget {
     if (this.definition?.['form:removable']?._ === false) return false
     const hasValue = this.value?._
     const parentIsGroup = this.parent instanceof ElementBase ? this.parent?.definition?.['form:widget']?._ === 'group' : false
-    const parentIsReadonly = this.parent instanceof ElementBase ? this.parent?.definition?.['form:readonly'] : false
+    const parentIsReadonly = this.parent instanceof ElementBase ? this.parent?.definition?.['form:readonly']?._ : false
     const isGroup = this.definition?.['form:widget']?._ === 'group'
     const isRequired = this.definition?.['form:required']?._
     const isReadonly = this.definition?.['form:readonly']?._

--- a/src/elements/ElementBase.ts
+++ b/src/elements/ElementBase.ts
@@ -157,10 +157,12 @@ export class ElementBase extends EventTarget {
     if (this.definition?.['form:removable']?._ === false) return false
     const hasValue = this.value?._
     const parentIsGroup = this.parent instanceof ElementBase ? this.parent?.definition?.['form:widget']?._ === 'group' : false
+    const parentIsReadonly = this.parent instanceof ElementBase ? this.parent?.definition?.['form:readonly'] : false
     const isGroup = this.definition?.['form:widget']?._ === 'group'
     const isRequired = this.definition?.['form:required']?._
-    
-    return !isRequired && hasValue && !parentIsGroup || isGroup
+    const isReadonly = this.definition?.['form:readonly']?._
+   
+    return !isRequired && hasValue && !parentIsGroup && !parentIsReadonly || ( isGroup && !isReadonly)
   }
 
   get languages () {
@@ -250,7 +252,7 @@ export class ElementBase extends EventTarget {
   async wrapper (innerTemplates: Array<typeof html> = [], isDisplayOnly = false) {
     const type = kebabize(this.constructor.name)
     const shouldShowEmpty = this.definition['form:translatable']?._ === 'always' && !Language.l10nLanguage
-
+    const isReadOnly = this.definition['form:readonly'] ?? false;
     return html`
     ${!shouldShowEmpty && (!isDisplayOnly || innerTemplates.length > 0) ? html`
     <div ref=${attributesDiff(this.wrapperAttributes)} name=${kebabize(lastPart(this.definition['@id']))} type="${type}">
@@ -261,7 +263,7 @@ export class ElementBase extends EventTarget {
         ${innerTemplates}
       </div>
     ` : ''}
-      ${this.definition['form:multiple']?._ && !isDisplayOnly ? html`<div>${this.addButton()}</div>` : html``}
+      ${this.definition['form:multiple']?._ && !isReadOnly && !isDisplayOnly ? html`<div>${this.addButton()}</div>` : html``}
     </div>
     ` : html``}`
   }

--- a/src/elements/ElementBase.ts
+++ b/src/elements/ElementBase.ts
@@ -252,7 +252,7 @@ export class ElementBase extends EventTarget {
   async wrapper (innerTemplates: Array<typeof html> = [], isDisplayOnly = false) {
     const type = kebabize(this.constructor.name)
     const shouldShowEmpty = this.definition['form:translatable']?._ === 'always' && !Language.l10nLanguage
-    const isReadOnly = this.definition['form:readonly'] ?? false;
+    const isReadOnly = this.definition['form:readonly']?._ ?? false
     return html`
     ${!shouldShowEmpty && (!isDisplayOnly || innerTemplates.length > 0) ? html`
     <div ref=${attributesDiff(this.wrapperAttributes)} name=${kebabize(lastPart(this.definition['@id']))} type="${type}">


### PR DESCRIPTION
This pull request fixes a use-case where a form element contains a combination of multiple and readonly. E.g. the `:dates` in the form below has `form:multiple true` and `form:readonly true`.  This means that one shouldn't expect a (+)-button to add a new `dates` entry, nor one should expect a (x)-button to remove an existing `dates` entry.

```
:dates
   a form:Field ;
   form:binding ex:dates ;
   form:widget "group" ;
   form:group "participant" ;
   form:multiple true ;
   form:readonly true ;
   form:order 1 .

:date
   a form:Field ;
   form:binding ex:date ;
   form:widget "date" ;
   form:group "dates" ;
   form:label "Dec 1"@en ;
   form:required true;
   form:readonly true ;
   form:order 0 .

:confirm
   a form:Field ;
   form:binding ex:confirm ;
   form:widget "checkbox" ;
   form:group "dates" ;
   form:label "Confirm"@en ;
   form:required true;
   form:saveEmptyValue true ;
   form:order 1 .  
```